### PR TITLE
Lo necesario para actualizar las versiones y operar en Ruby 2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# Local configuration and setup details
+config/thin.yml
+vendor/bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.1)
+    json (1.8.6)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)
     mime-types (1.25)


### PR DESCRIPTION
Con actualizar la versión de JSON ya se deja compilar. Al .gitignore, porque las bibliotecas en cuestión entran en el directorio vendor/bundle; si quieres replicar el cambio que hice, en tu árbol dale:

     $ bundle --path vendor/bundle

y bajará e instalará localmente lo que necesite.